### PR TITLE
Support old ios safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,4 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
 layout: home
 title: Home
 ---

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ layout: home
 title: Home
 ---
 
-<picture class="avatar" width="150px" height="150px">
+<picture class="avatar">
   <source
     srcset="/assets/images/avatar.webp"
     media="screen"

--- a/index.html
+++ b/index.html
@@ -12,13 +12,13 @@ title: Home
     media="screen"
     type="image/webp"
   />
-<img
-  alt="Doodles Logo"
-  src="/assets/images/avatar.webp"
-  width="150px"
-  height="150px"
-  class="avatar"
-/>
+  <img
+    srcset="/assets/images/avatar.png"
+    width="150px"
+    height="150px"
+    alt="The Doodles logo, a stylized letter D"
+  />
+</picture>
 
 <p>
   Hello, my name is Eduardo, but you can call me Doodles. Welcome to my little
@@ -73,8 +73,8 @@ title: Home
 
 <style>
   .avatar {
-    display: block;
-    margin: 0 auto;
+    display: flex;
+    justify-content: center;
   }
 
   .explore {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@ layout: home
 title: Home
 ---
 
+<picture class="avatar" width="150px" height="150px">
+  <source
+    srcset="/assets/images/avatar.webp"
+    media="screen"
+    type="image/webp"
+  />
 <img
   alt="Doodles Logo"
   src="/assets/images/avatar.webp"


### PR DESCRIPTION
Not tested on Safari yet, but should work according to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture). Now uses flexbox for image centering which I guess is ok. Closes #6 